### PR TITLE
element_image update field preview window fix

### DIFF
--- a/ip_cms/modules/developer/std_mod/elements/element_image.php
+++ b/ip_cms/modules/developer/std_mod/elements/element_image.php
@@ -70,10 +70,21 @@ class ElementImage extends Element{ //data element in area
     /*eof translation*/ 
 
     $image = BASE_URL.$this->copies[0]['destDir'].$value;
-      
+
+    $imageSize = getimagesize(BASE_DIR.$this->copies[0]['destDir'].$value);
+
+    $sizing = '';
+    if( $imageSize[0] >= 200 && $imageSize[0]>=$imageSize[1] ) // width more than 200 and image is horizontal
+    {
+      $sizing.='width="200" '; // limit only width (let browser scale height)
+    }elseif ( $imageSize[1] >= 200 && $imageSize[1] >= $imageSize[0] ) // height more than 200 and image is vertical
+      {
+        $sizing.='height="200" '; // limit only height (let browse scale width)
+      }
+
     $html = new StdModHtmlOutput();
       if($value)
-        $html->html('<span class="label"><img width="200" src="'.$image.'"/></span><br />');
+        $html->html('<span class="label"><img '.$sizing.'src="'.$image.'"/></span><br />');
       $html->inputFile($prefix, $this->disabledOnUpdate);
       if($value){
         $html->html('<span class="label"><input  class="stdModBox" type="checkbox" name="'.$prefix.'_delete"></span>');


### PR DESCRIPTION
Removing hardcoded width value of 200px for width and making additional logic to figure out what size to limit (height or width) when image is more than 200px on any axis without distorting (making bigger smaller images, and in case of vertical orientation of image it gets ugly).

This change makes it: maximum 200x200px image by limiting on bigger axis.
