### PR TITLE
IP 2.4 OSX error: Cannot redeclare class System

### DIFF
--- a/ip_cms/frontend/site.php
+++ b/ip_cms/frontend/site.php
@@ -1018,7 +1018,7 @@ class Site{
                     $systemFileExists = true;
                 }
 
-                if(file_exists($dir.$lock['mg_name'].'/'.$lock['m_name']."/System.php")){
+                if(!$systemFileExists && file_exists($dir.$lock['mg_name'].'/'.$lock['m_name']."/System.php")){
                     require_once($dir.$lock['mg_name'].'/'.$lock['m_name']."/System.php");
                     $systemFileExists = true;
                 }
@@ -1050,7 +1050,7 @@ class Site{
                     $systemFileExists = true;
                 }
 
-                if(file_exists($dir.$lock['mg_name'].'/'.$lock['m_name']."/System.php")){
+                if(!$systemFileExists && file_exists($dir.$lock['mg_name'].'/'.$lock['m_name']."/System.php")){
                     require_once($dir.$lock['mg_name'].'/'.$lock['m_name']."/System.php");
                     $systemFileExists = true;
                 }


### PR DESCRIPTION
Due to the filesystem of OSX (hfs+) by default it is case insensitive, so the new dinamic load of modules fails. This fix it.
