### PR TITLE
IP 2.4 OSX error: Cannot redeclare class System

### DIFF
--- a/ip_cms/modules/administrator/system/module.php
+++ b/ip_cms/modules/administrator/system/module.php
@@ -66,7 +66,7 @@ class Module
                     $systemFileExists = true;
                 }
 
-                if (file_exists(BASE_DIR . MODULE_DIR . $lock['mg_name'] . '/' . $lock['m_name'] . "/System.php")) {
+                if (!$systemFileExists && file_exists(BASE_DIR . MODULE_DIR . $lock['mg_name'] . '/' . $lock['m_name'] . "/System.php")) {
                     require_once(BASE_DIR . MODULE_DIR . $lock['mg_name'] . '/' . $lock['m_name'] . "/System.php");
                     $systemFileExists = true;
                 }


### PR DESCRIPTION
This issue appears too when you want to clear cache. So this modification is also necessary.
