### PR TITLE
Fixed profile update event's userId and password data

### DIFF
--- a/ip_cms/modules/community/user/controller.php
+++ b/ip_cms/modules/community/user/controller.php
@@ -314,7 +314,7 @@ class Controller  extends \Ip\Controller{
             $site->dispatchEvent('community', 'user', 'update_profile', array('user_id'=>$tmpUser['id']));
 
             //new event
-            $data = array('userId' => $insertId, $postData['password'] => $_POST['password'], 'profileData' => array_merge($data, $additionalFields));
+            $data = array('userId' => $tmpUser['id'], 'password' => $_POST['password'], 'profileData' => array_merge($data, $additionalFields));
             $dispatcher->notify(new Event($this, Event::PROFILE_UPDATE, $data));
 
 


### PR DESCRIPTION
The changes I'd mentioned in the Q2A answer to fix line 317 in the user controller: passing the correct userId and password to the profile update event.  These changes have been tested on my local copy of my SMF bridge, so the right information is getting passed.
