### PR TITLE
Make IP compatible with PHP 5.5 (hotfix)

### DIFF
--- a/ip_cms/includes/error_handler.php
+++ b/ip_cms/includes/error_handler.php
@@ -52,6 +52,9 @@ function myErrorHandler ($errno, $errstr, $errfile, $errline) {
         case E_COMPILE_ERROR:
             $message .= 'ERROR ';
             break;
+        case E_DEPRECATED:
+            // drop E_DEPRECATED to make IP work with PHP 5.5
+            return;            
         default:
             $message .= 'UNKNOWN EXCEPTION ';
             break;


### PR DESCRIPTION
By dropping E_DEPRECATED warnings in the error handler, ImpressPages can be made to work with PHP 5.5 (the only issue preventing IP to work in PHP 5.5 is the deprecation of the mysql_ module).

PHP 5.5 is the default PHP version in Ubuntu 13.10 (and probably in other distros as well), so I believe it is important to fix this, even though most hosters are still on 5.4.
