### PR TITLE
Add a function to get a theme asset

### DIFF
--- a/ip_cms/includes/Ip/View.php
+++ b/ip_cms/includes/Ip/View.php
@@ -451,6 +451,13 @@ class View{
         return $themeService->getThemeOption($name, $default);
     }
 
+	public function getThemeAsset($path) {
+        $url = BASE_URL . THEME_DIR . THEME;
+        if (0!== strpos($path, '/'))
+            $url = $url . '/'; 		 			
+        return $url.$path;
+    }
+
     private static function checkData ($data) {
         foreach ($data as $key => $value) {
             if (! preg_match('/^[a-zA-Z0-9_-]+$/', $key) || $key == '') {


### PR DESCRIPTION
Having to write `"<?php echo BASE_URL.THEME_DIR.THEME; ?>/img/foo.jpg"` everywhere in the theme is just ugly. Now you can write `"<?php echo $this->getThemeAsset('img/foo.jpg');?>"` instead, which I think looks much nicer.
