### PR TITLE
optimalize mouse cursor

### DIFF
--- a/Ip/Internal/Core/assets/admin/admin.css
+++ b/Ip/Internal/Core/assets/admin/admin.css
@@ -123,6 +123,7 @@
 }
 .ip a {
   background: transparent;
+  cursor: pointer;
 }
 .ip a:active,
 .ip a:hover {
@@ -8117,6 +8118,10 @@
 }
 .ip .ipAdminPanel ._widgets ._container {
   margin: 0 40px;
+}
+.ip .ipAdminPanel ._widgets ._container li,
+.ip .ipAdminPanel ._widgets ._container li a {
+  cursor: move;
 }
 .ip .ipAdminPanel ._widgets ._container:before,
 .ip .ipAdminPanel ._widgets ._container:after {


### PR DESCRIPTION
The menu links, the widget arrows and the page revisions have got default cursor in FF 28 (Win8.0, 32bit).
