### PR TITLE
Allow to sort option to Grid without drag & drop function

### DIFF
--- a/Ip/Internal/Grid/Model/Config.php
+++ b/Ip/Internal/Grid/Model/Config.php
@@ -202,7 +202,15 @@ class Config
 
     public function allowSort()
     {
-        return !empty($this->config['sortField']);
+		if (!empty($this->config['sortField'])){
+			if (!empty($this->config['allowSort'])){
+				return (mb_strtoupper(trim($this->config['allowSort'])) === mb_strtoupper("true")) ? TRUE : FALSE;
+			} else {
+				return TRUE;
+			}
+		} else {
+			return FALSE;
+		}
     }
 
     public function allowDelete()


### PR DESCRIPTION
The sortField is used for order by statement in SQL of a Grid. It was also used for the drag & drop reorder function in a grid view. So it was not possible to use order by for fields like name, date, etc..
Now it's possible to use the order by option without the drag & drop function. You have simple to
add 'allowSort' => "false" option in Plugins "AdminController.php".
