### PR TITLE
globRecursive

### DIFF
--- a/Ip/Internal/Design/LessCompiler.php
+++ b/Ip/Internal/Design/LessCompiler.php
@@ -180,10 +180,10 @@ class LessCompiler
      */
     protected function globRecursive($pattern, $flags = 0)
     {
-        //some systems return false instead of empty array if no matches found in glob function
         $files = glob($pattern, $flags);
         if (!is_array($files)) {
-            return array();
+            //some systems return false instead of empty array if no matches found in glob function
+            $files = array();
         }
 
         $dirs = glob(dirname($pattern) . '/*', GLOB_ONLYDIR | GLOB_NOSORT);


### PR DESCRIPTION
When a system reports no files found as false instead of an empty array, globRecursive didn't iterate through the directories in the folder.

This made it so that on such systems you can't put .less files in subdirectories of your theme folder.
