### PR TITLE
Logo bug in some systems

### DIFF
--- a/Ip/Internal/InlineManagement/Entity/Logo.php
+++ b/Ip/Internal/InlineManagement/Entity/Logo.php
@@ -85,7 +85,7 @@ class Logo
                     'height' => $this->getRequiredHeight(),
                     'quality' => 100
                 );
-                $requestedName = ipGetOptionLang('Config.websiteTitle');
+                $requestedName = \Ip\Internal\Text\Specialchars::url(ipGetOptionLang('Config.websiteTitle'));
                 $this->image = ipReflection($this->getImageOrig(), $transform, $requestedName);
             }
         } else {


### PR DESCRIPTION
Logo doesn't work if page name has has special chars, not sure if this is best solution.
