### PR TITLE
Fix Undefined index: websiteId on 1 step installation

### DIFF
--- a/install/index.php
+++ b/install/index.php
@@ -11,6 +11,10 @@ if ((PHP_MAJOR_VERSION < 5) || (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION < 3)
 
 require_once(__DIR__ . '/../Ip/Application.php');
 
+if(!isset($_SESSION)) {
+	session_start();
+}
+
 $application = new \Ip\Application(__DIR__ . '/config.php');
 $application->init();
 $options = array(


### PR DESCRIPTION
I discovered this error that cause a js alert popup on the very first step of the installation wizard.
This is caused by the websiteId in session is empty, than the method Model::sendUsageStatistics try to get from it db (and at the very first step db connection is not initialized).
The problem is related to session that is not yet started at the very first step, so I initialized it (if not already started) in the install/index.php.

This is the error I get (PHP 5.4, Windows 7):
http://screencast.com/t/SPrrDlKX

Unexpected error.<br />
<b>Notice</b>:  Undefined index: websiteId in <b>C:\WORKAREA\Progetti\fabvla\impresspages\htdocs\install\Plugin\Install\Helper.php</b> on line <b>353</b><br />
