### PR TITLE
Fixed Correct Spelling

### DIFF
--- a/install/Plugin/Install/Helper.php
+++ b/install/Plugin/Install/Helper.php
@@ -30,7 +30,7 @@ class Helper
         $languages['pl'] = 'Polski';
         $languages['ro'] = 'Română';
         $languages['ru'] = 'Русский';
-        $languages['tr'] = 'Türk';
+        $languages['tr'] = 'Türkçe';
 
         return $languages;
     }


### PR DESCRIPTION
Fixed correct spelling "Türkçe" instead of using "Türk". Türk is mean race definition. Türkçe is mean Turkish Language.
