### PR TITLE
extra method removeAll() in Storage.php

### DIFF
--- a/Ip/Storage.php
+++ b/Ip/Storage.php
@@ -134,5 +134,27 @@ class Storage
         ipDb()->execute($sql, $params);
 
     }
+    
+    /**
+     * Remove all storage values for the plugin
+     *
+     * @param string $pluginName Plugin name
+     */
+    public function removeAll($pluginName)
+    {
+        $sql = '
+            DELETE FROM
+                ' . ipTable('storage') . '
+            WHERE
+                `plugin` = :plugin
+        ';
+
+        $params = array(
+            ':plugin' => $pluginName
+        );
+
+        ipDb()->execute($sql, $params);
+
+    }
 
 }


### PR DESCRIPTION
Add an extral removeAll() method to remove all storage values for the specified plugin. useful for plugin uninstall cleanup operation.
