### PR TITLE
Added missing translate

### DIFF
--- a/Ip/Internal/Translations/translations/Ip-admin-en.json
+++ b/Ip/Internal/Translations/translations/Ip-admin-en.json
@@ -364,5 +364,6 @@
     "Contact form": "Contact form",
     "Logo gallery": "Logo gallery",
     "Photo gallery": "Photo gallery",
-    "Table": "Table"
+    "Table": "Table",
+    "Email preview" : "Email preview"
 }


### PR DESCRIPTION
Added missing translate "Email preview" on Ip/Internal/Email/view/previewModal.php line 7 

https://github.com/impresspages/ImpressPages/blob/master/Ip/Internal/Email/view/previewModal.php#L7
