### PR TITLE
Zero-Less-Variable

### DIFF
--- a/Ip/Internal/Design/LessCompiler.php
+++ b/Ip/Internal/Design/LessCompiler.php
@@ -96,9 +96,9 @@ class LessCompiler
                 continue; // ignore invalid nodes
             }
 
-            if (!empty($config[$option['name']])) {
+            if (!empty($config[$option['name']]) || $config[$option['name']] === '0') {
                 $rawValue = $config[$option['name']];
-            } elseif (!empty($option['default'])) {
+            } elseif (!empty($option['default']) || $option['default'] === '0') {
                 $rawValue = $option['default'];
             } else {
                 continue; // ignore empty values


### PR DESCRIPTION
Bugfix: Accept the value '0' as a template option value. Fixes #591 .
