### PR TITLE
Publish still active after widget removed

### DIFF
--- a/Ip/Internal/Content/Model.php
+++ b/Ip/Internal/Content/Model.php
@@ -696,6 +696,8 @@ class Model
               `revisionId` = :revisionId
               AND
               `name` != 'Columns'
+              AND
+              `isDeleted` = 0
             ORDER BY
               blockName, `position`
         ";
@@ -716,6 +718,8 @@ class Model
               `revisionId` = :revisionId
               AND
               `name` != 'Columns'
+              AND
+              `isDeleted` = 0
             ORDER BY
               blockName, `position`
         ";


### PR DESCRIPTION
If a widget is removed from the page and then it's published, the
Publish button is still active until published again.
