### PR TITLE
Missing block outline after removing all widgets.

### DIFF
--- a/Ip/Internal/Content/assets/management/content.js
+++ b/Ip/Internal/Content/assets/management/content.js
@@ -34,7 +34,7 @@ var ipContent = new function () {
                 var $block = $widget.closest('.ipBlock');
                 $widget.remove();
                 if ($block.children('.ipWidget').length == 0) {
-                    $this.addClass('ipbEmpty');
+                    $block.addClass('ipbEmpty');
                 }
 
 


### PR DESCRIPTION
Fixes an issue where by removing all of the widgets from a block, it becomes 'invisible'.