### PR TITLE
Static Widgets Cleanup

### DIFF
--- a/Ip/Internal/Content/Service.php
+++ b/Ip/Internal/Content/Service.php
@@ -91,4 +91,9 @@ class Service
         return Model::getWidgetRecord($widgetId);
     }
 
+    public static function removeWidget($widgetId)
+    {
+        Model::removeWidget($widgetId);
+    }
+
 }


### PR DESCRIPTION
Proposal for how to implement database cleanup of widgets placed within static blocks, which are currently not handled by `removeOldRevisions()`, as they are persisted with `revisionId=0`.
This should fix issue #709.