### PR TITLE
fix 'selectFields' error and add a 'allowDB' option in GRID

### DIFF
--- a/Ip/Internal/Grid/Model/Actions.php
+++ b/Ip/Internal/Grid/Model/Actions.php
@@ -129,7 +129,7 @@ class Actions
         $languageData = array();
         $languages = ipContent()->getLanguages();
         foreach ($fields as $field) {
-            if (empty($field['field']) ||  $field['field'] == $this->subgridConfig->idField() || isset($field['allowUpdate']) && !$field['allowUpdate'] || !empty($field['type']) && $field['type'] == 'Tab') {
+            if (empty($field['field']) ||  $field['field'] == $this->subgridConfig->idField() || isset($field['allowUpdate']) && !$field['allowUpdate'] || !empty($field['type']) && $field['type'] == 'Tab' || isset($field['allowDB']) && !$field['allowDB']) {
                 continue;
             }
 
@@ -241,7 +241,7 @@ class Actions
         $dbData = array();
         $languageData = array();
         foreach ($fields as $field) {
-            if (!empty($field['type']) && $field['type'] == 'Tab' && empty($field['preview'])) {
+            if (!empty($field['type']) && $field['type'] == 'Tab' && empty($field['preview']) || isset($field['allowDB']) && !$field['allowDB']) {
                 continue;
             }
 

--- a/Ip/Internal/Grid/Model/Config.php
+++ b/Ip/Internal/Grid/Model/Config.php
@@ -231,6 +231,10 @@ class Config
         return !array_key_exists('allowUpdate', $this->config) || $this->config['allowUpdate'];
     }
 
+    public function allowDB()
+    {
+        return !array_key_exists('allowDB', $this->config) || $this->config['allowDB'];
+    }
     public function allowSort()
     {
         if (!empty($this->config['sortField'])) {

--- a/Ip/Internal/Grid/Model/Field/Checkbox.php
+++ b/Ip/Internal/Grid/Model/Field/Checkbox.php
@@ -62,7 +62,9 @@ class Checkbox extends \Ip\Internal\Grid\Model\Field
             'layout' => $this->layout,
             'attributes' => $this->attributes
         ));
+        if (isset($curData[$this->field])){
         $field->setValue($curData[$this->field]);
+        }
         return $field;
     }
 

--- a/Ip/Internal/Grid/Model/Field/Checkboxes.php
+++ b/Ip/Internal/Grid/Model/Field/Checkboxes.php
@@ -72,7 +72,9 @@ class Checkboxes extends \Ip\Internal\Grid\Model\Field
             'layout' => $this->layout,
             'attributes' => $this->attributes
         ));
+        if (isset($curData[$this->field])){
         $field->setValue(json_decode($curData[$this->field]));
+        }
         return $field;
     }
 

--- a/Ip/Internal/Grid/Model/Field/Color.php
+++ b/Ip/Internal/Grid/Model/Field/Color.php
@@ -29,7 +29,9 @@ class Color extends \Ip\Internal\Grid\Model\Field\Text
             'layout' => $this->layout,
             'attributes' => $this->attributes
         ));
+        if (isset($curData[$this->field])){
         $field->setValue($curData[$this->field]);
+        }
         return $field;
     }
 

--- a/Ip/Internal/Grid/Model/Field/Currency.php
+++ b/Ip/Internal/Grid/Model/Field/Currency.php
@@ -84,7 +84,9 @@ class Currency extends \Ip\Internal\Grid\Model\Field
         if (!empty($curData[$this->field])) {
             $curData[$this->field] = $curData[$this->field] / 100;
         }
+        if (isset($curData[$this->field])){
         $field->setValue($curData[$this->field]);
+        }
         return $field;
     }
 

--- a/Ip/Internal/Grid/Model/Field/Integer.php
+++ b/Ip/Internal/Grid/Model/Field/Integer.php
@@ -38,7 +38,9 @@ class Integer extends \Ip\Internal\Grid\Model\Field
             'layout' => $this->layout,
             'attributes' => $this->attributes
         ));
+        if (isset($curData[$this->field])){
         $field->setValue($curData[$this->field]);
+        }
         return $field;
     }
 

--- a/Ip/Internal/Grid/Model/Field/Radio.php
+++ b/Ip/Internal/Grid/Model/Field/Radio.php
@@ -75,7 +75,9 @@ class Radio extends \Ip\Internal\Grid\Model\Field
             'layout' => $this->layout,
             'attributes' => $this->attributes
         ));
+        if (isset($curData[$this->field])){
         $field->setValue($curData[$this->field]);
+        }
         return $field;
     }
 

--- a/Ip/Internal/Grid/Model/Field/RepositoryFile.php
+++ b/Ip/Internal/Grid/Model/Field/RepositoryFile.php
@@ -96,11 +96,12 @@ class RepositoryFile extends \Ip\Internal\Grid\Model\Field
         if ($this->fileLimit !== null) {
             $field->setFileLimit($this->fileLimit);
         }
-
+        if (isset($curData[$this->field])){
         if ($this->fileLimit == 1) {
             $field->setValue(array($curData[$this->field]));
         } else {
             $field->setValue(json_decode($curData[$this->field]));
+            }
         }
         return $field;
     }

--- a/Ip/Internal/Grid/Model/Field/RichText.php
+++ b/Ip/Internal/Grid/Model/Field/RichText.php
@@ -29,7 +29,9 @@ class RichText extends \Ip\Internal\Grid\Model\Field\Text
             'layout' => $this->layout,
             'attributes' => $this->attributes
         ));
+        if (isset($curData[$this->field])){
         $field->setValue($curData[$this->field]);
+        }
         return $field;
     }
 

--- a/Ip/Internal/Grid/Model/Field/Select.php
+++ b/Ip/Internal/Grid/Model/Field/Select.php
@@ -75,7 +75,9 @@ class Select extends \Ip\Internal\Grid\Model\Field
             'layout' => $this->layout,
             'attributes' => $this->attributes
         ));
+        if (isset($curData[$this->field])){
         $field->setValue($curData[$this->field]);
+        }
         return $field;
     }
 

--- a/Ip/Internal/Grid/Model/Field/Text.php
+++ b/Ip/Internal/Grid/Model/Field/Text.php
@@ -38,7 +38,9 @@ class Text extends \Ip\Internal\Grid\Model\Field
             'layout' => $this->layout,
             'attributes' => $this->attributes
         ));
+        if (isset($curData[$this->field])){
         $field->setValue($curData[$this->field]);
+        }
         return $field;
     }
 

--- a/Ip/Internal/Grid/Model/Field/Textarea.php
+++ b/Ip/Internal/Grid/Model/Field/Textarea.php
@@ -29,7 +29,9 @@ class Textarea extends \Ip\Internal\Grid\Model\Field\Text
             'layout' => $this->layout,
             'attributes' => $this->attributes
         ));
+        if (isset($curData[$this->field])){
         $field->setValue($curData[$this->field]);
+        }
         return $field;
     }
 

--- a/Ip/Internal/Grid/Model/Field/Url.php
+++ b/Ip/Internal/Grid/Model/Field/Url.php
@@ -29,7 +29,9 @@ class Url extends \Ip\Internal\Grid\Model\Field\Text
             'layout' => $this->layout,
             'attributes' => $this->attributes
         ));
+        if (isset($curData[$this->field])){
         $field->setValue($curData[$this->field]);
+        }
         return $field;
     }
 


### PR DESCRIPTION
fix: when you use 'selectFields' will cause the edit form can't pop up;

update: add an "allowDB" Grid form field option, now you can set any field which you want to deal with the data by yourself, you can add your custom code in both "createFormFilter" and "updateFormFilter";

e.g: 
say that you have a TEXT field, and a SELECT filed you want show all history of TEXT field in database,
you can mask the SELECT field with 'allowDB' => false, and deal with the data by yourself in "createFormFilter" and "updateFormFilter" now;