### PR TITLE
Modify content-type for json response

### DIFF
--- a/Ip/Response/Json.php
+++ b/Ip/Response/Json.php
@@ -27,7 +27,7 @@ class Json extends \Ip\Response
 
     public function send()
     {
-        $this->addHeader('Content-type: text/json; charset=utf-8');
+        $this->addHeader('Content-type: application/json; charset=utf-8');
         parent::send();
     }
 


### PR DESCRIPTION
The MIME media type for JSON text is application/json. (Source: RFC 4627 - http://www.ietf.org/rfc/rfc4627.txt).
According to the rfc, the media type must be 'application/json' instead of 'text/json'. Standard browser (ie: webkit, geko), extensions and libraries automatically recognize application/json MIME media type.
Note : The default encoding is UTF-8. (as specified in the rfc). So no changes regarding the encoding is needed.
Note: I would mention that this isn't a mandatory but it is a rules from rfc.
Another point to underline. Sometimes, we have an issue on IE (don't know which version) with application/json. The MIME should be 'text/javascript'. A patch may be necessary for this case.