### PR TITLE
Force submit widgetData on Gallery modal submit via keyboard

### DIFF
--- a/Ip/Internal/Content/Widget/Gallery/assets/Gallery.js
+++ b/Ip/Internal/Content/Widget/Gallery/assets/Gallery.js
@@ -364,6 +364,12 @@ var IpWidget_Gallery = function () {
             if (callback) {
                 $.proxy(callback, context)();
             }
+        });
+
+        // Force include widgetData on submit. Overwrites default submit action. See ipInitForms()
+        this.settingsPopup.find('.ipsAjaxSubmit').off('submit.ipSubmit').on('submit.ipSubmit', function (e) {
+            $.proxy(saveSettings, context)(callback);
+            e.preventDefault();
         })
     };
 


### PR DESCRIPTION
Otherwise default functionality from form.js is executed showing HTML source in alert.
This function overwrites default (forms.js) submit behaviour,