### PR TITLE
Added user friendly layout naming

### DIFF
--- a/Ip/Internal/Design/Model.php
+++ b/Ip/Internal/Design/Model.php
@@ -312,7 +312,14 @@ class Model
         foreach ($files as $filename) {
             if ('php' == strtolower(pathinfo($filename, PATHINFO_EXTENSION))) {
                 if ($filename[0] != '_') {
-                    $layouts[] = $filename;
+                    $file_contents = file_get_contents($themeDir.$filename);
+                    preg_match_all("(@Layout Name:(.*)\n)siU", $file_contents, $file_layout);
+                    if (isset($file_layout[1]) && isset($file_layout[1][0]) && !empty($file_layout[1][0])) {
+                        $layout_name = preg_replace('/[^a-zA-Z0-9\s]/', '', $file_layout[1][0]);
+                    } else {
+                        $layout_name = '';
+                    }
+                    $layouts[] = array($filename, trim($layout_name) != '' ? $layout_name : $filename);
                 }
             }
         }

--- a/Ip/Internal/Pages/Helper.php
+++ b/Ip/Internal/Pages/Helper.php
@@ -96,17 +96,13 @@ class Helper
         $form->addField($field);
 
         $layouts = \Ip\Internal\Design\Service::getLayouts();
-        $values = array();
-        foreach ($layouts as $layout) {
-            $values[] = array($layout, $layout);
-        }
 
         $field = new \Ip\Form\Field\Select(
             array(
                 'name' => 'layout',
                 'label' => __('Layout', 'Ip-admin', false),
                 'value' => $menu['layout'],
-                'values' => $values,
+                'values' => $layouts,
             ));
         $form->addField($field);
 
@@ -178,17 +174,12 @@ class Helper
 
 
         $layouts = \Ip\Internal\Design\Service::getLayouts();
-        $options = array();
-        foreach ($layouts as $layout) {
-            $options[] = array($layout, $layout);
-        }
-
 
         $field = new \Ip\Form\Field\Select(
             array(
                 'name' => 'layout',
                 'label' => __('Layout', 'Ip-admin', false),
-                'values' => $options,
+                'values' => $layouts,
                 'value' => $page->getLayout()
             ));
         $form->addField($field);

--- a/Theme/Air/home.php
+++ b/Theme/Air/home.php
@@ -1,3 +1,4 @@
+<?php // @Layout name: Home ?>
 <?php echo ipView('_header.php')->render(); ?>
     <div class="main col_12">
         <?php echo ipBlock('main')->exampleContent(' '); ?>

--- a/Theme/Air/main.php
+++ b/Theme/Air/main.php
@@ -1,3 +1,4 @@
+<?php // @Layout name: Main ?>
 <?php echo ipView('_header.php')->render(); ?>
     <div class="sidenav col_12 col_md_12 col_lg_3 left">
         <nav<?php if (ipGetThemeOption('collapseSidebarMenu') == 'yes') { echo ' class="collapse"'; }?>>

--- a/Theme/QuickStart/main.php
+++ b/Theme/QuickStart/main.php
@@ -1,3 +1,4 @@
+<?php // @Layout name: Main ?>
 <?php echo ipDoctypeDeclaration(); ?>
 <html<?php echo ipHtmlAttributes(); ?>>
 <head>


### PR DESCRIPTION
Removed hardcoded layout name options array from layout select fields in page forms.
Added layout name parsing and page layout select field options array with names in page forms.
Added example layout names in demo themes.

Layout name can be added by adding `@Layout name: *chosen name*` attribute to layout PHP file. This can either be done with PHP `<?php // @Layout name: *chosen name* ?>` or HTML `<!-- @Layout name: *chosen name* -->`. Need to remember that HTML way shows the layout name to public in rendered website DOM.

Layout PHP files with underscore still ignored as being partials like in previous ImpressPages versions.