### PR TITLE
Removed CSRF check for public environment routes

### DIFF
--- a/Ip/Application.php
+++ b/Ip/Application.php
@@ -238,7 +238,7 @@ class Application
 
 
         //check for CSRF attack
-        if (empty($options['skipCsrfCheck']) && $request->isPost() && ($request->getPost(
+        if (ipRoute()->environment() != \Ip\Route::ENVIRONMENT_PUBLIC && empty($options['skipCsrfCheck']) && $request->isPost() && ($request->getPost(
                     'securityToken'
                 ) != $this->getSecurityToken(
                 )) && (empty($routeAction['controller']) || $routeAction['controller'] != 'PublicController')


### PR DESCRIPTION
Removed CSRF check for routes with public environment set and therefore let custom routes to be directed to custom controllers, not only PublicController.