### PR TITLE
Plugin Icon and Translate in Title

### DIFF
--- a/Ip/Internal/Admin/Event.php
+++ b/Ip/Internal/Admin/Event.php
@@ -23,12 +23,16 @@ class Event
         if (isset($curModule) && $curModule) {
             $title = $curModule;
             $plugin = \Ip\Internal\Plugins\Service::getPluginConfig($curModule);
-            if ($plugin) {
-                $title = $plugin['title'];
-            }
+            
             $curModTitle = __($title, 'Ip-admin', false);
             $curModUrl = ipActionUrl(array('aa' => $curModule . '.index'));
             $curModIcon = Model::getAdminMenuItemIcon($curModule);
+            
+            //if $curModule is a plugin try to translate and get icon in config.json
+            if ($plugin) {
+                $curModTitle = __($plugin['title'], $curModule, false);
+                $curModIcon = isset($plugin['icon']) ? $plugin['icon'] : $curModIcon;
+            }
         }
 
         $navbarButtons = array(

--- a/Ip/Internal/Admin/Model.php
+++ b/Ip/Internal/Admin/Model.php
@@ -84,7 +84,7 @@ class Model
             $moduleItem = new \Ip\Internal\Admin\MenuItem();
             $moduleItem->setTitle(__($plugin['title'], 'Ip-admin', false));
             $moduleItem->setUrl(ipActionUrl(array('aa' => $plugin['name'])));
-            $moduleItem->setIcon($this->getAdminMenuItemIcon($plugin['name']));
+            $moduleItem->setIcon($this->getAdminMenuPluginIcon($plugin['name']));
             if ($plugin['name'] == $currentModule) {
                 $moduleItem->markAsCurrent(true);
             }
@@ -96,6 +96,17 @@ class Model
         $answer = ipFilter('ipAdminMenu', $answer);
 
         return $answer;
+    }
+    
+    /**
+     * Function to get icon from plugin config
+     * @param $module
+     * @return string
+     */
+    public static function getAdminMenuPluginIcon($module)
+    {
+        $conf = \Ip\Internal\Plugins\Service::getPluginConfig($module);
+        return isset($conf['icon']) ? $conf['icon'] : 'fa-cog';
     }
 
     public static function getAdminMenuItemIcon($module)

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman


### PR DESCRIPTION
Add ability to use icon in menu and title and the translation.

In config.json of the Plugin just add:

"icon": "fa-plus"