### PR TITLE
Undefined $form->render()

### DIFF
--- a/Ip/Internal/Pages/Helper.php
+++ b/Ip/Internal/Pages/Helper.php
@@ -275,7 +275,7 @@ class Helper
             ));
         $form->addField($field);
 
-        $form = ipFilter('ipPagePropertiesForm', $form, array('pageId' => $pageId));
+        //$form = ipFilter('ipPagePropertiesForm', $form, array('pageId' => $pageId));
 
         return $form;
     }


### PR DESCRIPTION
With this line on open Page Properties throws this error:
 Fatal error: Call to a member function render() on a non-object in \Ip\Internal\Pages\view\pageProperties.php on line 10