### PR TITLE
feat(repository): lazy loading, range selection + fix(repository): fix endless force delete 

### DIFF
--- a/Ip/Internal/Repository/assets/ipRepositoryAll.js
+++ b/Ip/Internal/Repository/assets/ipRepositoryAll.js
@@ -527,7 +527,7 @@
                                 $(this).remove();
                                 // recalculating selected files
                                 $.proxy(methods._countSelected, repositoryContainer)();
-                            })
+                            });
                         ;
                     }
 
@@ -535,7 +535,13 @@
                     // notify that not all files were deleted
                     if (parseInt(response.notRemovedCount) > 0) {
                         if (confirm(ipRepositoryTranslate_delete_warning)) {
-                            $.proxy(methods._executeDelete, context)(files, true);
+
+                            // do not include already deleted files in the request, otherwise
+                            // we'll end up in an endless loop, telling the user that some files
+                            // could not be deleted (because they have been deleted already)
+                            $.proxy(methods._executeDelete, context)(files.filter(function(x) {
+                                return !~response.deletedFiles.indexOf(x.fileName);
+                            }), true);
                         }
                     }
                 },

--- a/Ip/Internal/Repository/assets/ipRepositoryAll.js
+++ b/Ip/Internal/Repository/assets/ipRepositoryAll.js
@@ -528,7 +528,6 @@
                                 // recalculating selected files
                                 $.proxy(methods._countSelected, repositoryContainer)();
                             });
-                        ;
                     }
 
 

--- a/Ip/Internal/Repository/view/popup.php
+++ b/Ip/Internal/Repository/view/popup.php
@@ -49,7 +49,7 @@
                     <ul>
                         <li class="ipsFileTemplate">
                             <i class=""></i>
-                            <img src="" alt="" title="" />
+                            <img src="<?php echo ipFileUrl('Ip/Internal/Content/assets/img/empty.gif') ?>" alt="" title="" />
                             <span></span>
                         </li>
                     </ul>


### PR DESCRIPTION
**Lazy loading for thumbnails in repository (image browser)**

On websites with a large amount of images (1000+) the image browser by default loads all thumbnails. This takes a lot of times and blocks further web requests until all images are loaded. To prevent this, I implemented lazy loading. Now only the thumbnails for currently visible images are loaded. Once the user resizes the window, scrolls it, uses the search function or uploads a new image, additional thumbnails are loaded on demand. 

For reference see https://github.com/impresspages/ImpressPages/issues/800

**Allow selecting of multiple images/files in repository (image browser) when holding the shift key**

Sometimes you need to delete many images at once and selecting them one by one would take a lot of time. I added the possibility to select many images at once when holding the <kbd>SHIFT</kbd> key. A short demo is available here: http://recordit.co/UlMSj0cORr

**Fix force-delete of images/files in repository (image browser)**

The default delete function of the repository component supports deleting of multiple files and can handle the situation when one or multiple of the requested files could not be deleted for some reason. The user is then prompted to force delete the file, however, instead of requesting the deleting of only failed files, the repository component sends the whole list, including already deleted files to the server. This causes an endless loop as the server will always fail to delete some files as they have been removed in a previous request. I fixed this by filtering the file list sent to the server on force delete. 