### PR TITLE
One time only valid captchas

### DIFF
--- a/Ip/Form/Field/Captcha.php
+++ b/Ip/Form/Field/Captcha.php
@@ -66,6 +66,9 @@ class Captcha extends Field
         $this->addValidator('Required');
 
         parent::__construct($options);
+        if (isset($options['allowMoreThanOneUse'])) {
+            $this->options['allowMoreThanOneUse']=$options['allowMoreThanOneUse'];
+        }
     }
 
     /**
@@ -138,6 +141,11 @@ class Captcha extends Field
         );
         if (strtolower($code) !== $realCode) {
             return $errorText;
+        }
+        // Check the captcha options to see if it allows the (unsafe) option more than one use!
+        if (!isset($this->options['allowMoreThanOneUse'])) {
+            // remove the id from $_SESSION
+            unset( $_SESSION['developer']['form']['field']['captcha'][$id] );
         }
 
         return parent::validate($values, $valueKey, $environment);


### PR DESCRIPTION
The capchas should have one use only, otherwise an attacker can send several times the same form with the same captcha once it is solved.
Optionally, a parameter is added to continue with the previous behaviour.